### PR TITLE
Fix input CSS

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -25,7 +25,7 @@ export default function Card(props) {
         <li className="todoItem">
             {editMode ? (
                 <input
-                    className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+                    className="editInput"
                     type="text"
                     value={editValue}
                     onChange={handleChange}

--- a/src/index.css
+++ b/src/index.css
@@ -93,6 +93,24 @@ p {
     background: var(--white);
 }
 
+.editInput {
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    appearance: none;
+    border: 1px solid #d1d5db;
+    border-radius: 0.25rem;
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    color: #4a5568;
+    line-height: 1.5;
+    outline: none;
+    transition: box-shadow 0.2s;
+}
+
+.editInput:focus {
+    box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.5);
+    border-color: #3182ce;
+}
+
 .todoItem p {
     flex: 1;
 }


### PR DESCRIPTION
This pull request addresses an issue with the styling of the task editing input field by removing the broken Tailwind CSS classes from the component-specific styles and consolidating them into the index.css file. 

# Before
![before](https://github.com/user-attachments/assets/af5f552c-b631-4232-b53a-1f5bc36f9e5c)
# After
![after](https://github.com/user-attachments/assets/5ce71771-06b8-404e-9b6c-16ff50aee55b)

